### PR TITLE
Fix query timestream

### DIFF
--- a/src/main/java/it/pagopa/interop/probing/statistics/api/service/impl/TimestreamServiceImpl.java
+++ b/src/main/java/it/pagopa/interop/probing/statistics/api/service/impl/TimestreamServiceImpl.java
@@ -59,13 +59,22 @@ public class TimestreamServiceImpl implements TimestreamService {
  // @formatter:off
     String queryString = "WITH binned_timeseries AS ("
         //approximates the times using the polling frequency
-        + "SELECT  BIN(time, "+pollingFrequency+"m) AS binned_timestamp, status, response_time " 
-        + "FROM " + database + "." + table + " " 
-        + "WHERE time between " 
+        + "SELECT  BIN(v.time, "+pollingFrequency+"m) AS binned_timestamp, v.status, v.response_time " 
+        + "FROM " + database + "." + table + " v " 
+        //this join deletes all the duplicates time that will be created with the approximation
+        + "INNER JOIN "
+        + "(SELECT h.*,row_number() over (partition by BIN(h.time, "+pollingFrequency+"m) order by BIN(h.time, "+pollingFrequency+"m) desc) as seqnum "
+        + "FROM  " + database + "." + table + " h  "
+        + "WHERE h.time between " 
+        + (Objects.nonNull(startDate) ? "'" + startDate.format(DateTimeFormatter.ofPattern(TIME_FORMAT)) + "'" : "ago(1d) ") 
+        +" and "+ (Objects.nonNull(endDate) ? "'" + endDate.format(DateTimeFormatter.ofPattern(TIME_FORMAT)) + "'" : "now() ") 
+        + "and h.eservice_record_id = '"+ eserviceRecordId + "') h "
+        + "ON v.time = h.time and h.seqnum = 1 "
+        + "WHERE v.time between " 
         + (Objects.nonNull(startDate) ? "'" + startDate.format(DateTimeFormatter.ofPattern(TIME_FORMAT)) + "'" : "ago(1d)") 
         +" and "+ (Objects.nonNull(endDate) ? "'" + endDate.format(DateTimeFormatter.ofPattern(TIME_FORMAT)) + "'" : "now()") 
-        + "and eservice_record_id = '"+ eserviceRecordId + "' " 
-        + "GROUP BY  BIN(time, "+pollingFrequency+"m) , status , response_time "
+        + "and v.eservice_record_id = '"+ eserviceRecordId + "' " 
+        + "GROUP BY  BIN(v.time, "+pollingFrequency+"m) , v.status , v.response_time "
         + "), interpolated_timeseries AS ( "
         //create a timestream timeseries in which all the times included in the sequence(2) but missing in the timeseries(1) are filled with N/D value 
         + "SELECT INTERPOLATE_FILL( "

--- a/src/main/java/it/pagopa/interop/probing/statistics/api/service/impl/TimestreamServiceImpl.java
+++ b/src/main/java/it/pagopa/interop/probing/statistics/api/service/impl/TimestreamServiceImpl.java
@@ -69,6 +69,7 @@ public class TimestreamServiceImpl implements TimestreamService {
         +" and "+ (Objects.nonNull(endDate) ? "'" + endDate.format(DateTimeFormatter.ofPattern(TIME_FORMAT)) + "'" : "now() ") 
         + "and eservice_record_id = '"+ eserviceRecordId + "') "
         + "WHERE seqnum = 1 "
+        + "ORDER BY  BIN(time, "+pollingFrequency+"m)"
         + "), interpolated_timeseries AS ( "
         //create a timestream timeseries in which all the times included in the sequence(2) but missing in the timeseries(1) are filled with N/D value 
         + "SELECT INTERPOLATE_FILL( "


### PR DESCRIPTION
During the approximation of the times, needed for the interpolation , the non-approximated times which would create the duplicates, will be eliminated leaving only the one with the lower time.